### PR TITLE
fix(cli): find shell binary on macOS (no .exe extension)

### DIFF
--- a/cli/bagidea
+++ b/cli/bagidea
@@ -123,11 +123,10 @@ function help() {
   console.log("");
 }
 
+const { findShellExe: _findShell } = require("./find-shell");
+
 function findShellExe() {
-  const isMac = process.platform === "darwin";
-  const name = isMac ? "bagidea-office-shell" : "bagidea-office-shell.exe";
-  const exe = path.join(ROOT, "shell", "target", "release", name);
-  return fs.existsSync(exe) ? exe : null;
+  return _findShell(ROOT);
 }
 
 const NOT_RUNNING = () => bad(`The office isn't running — run ${c.accent}bagidea start${c.reset} first`);

--- a/cli/bagidea
+++ b/cli/bagidea
@@ -124,7 +124,9 @@ function help() {
 }
 
 function findShellExe() {
-  const exe = path.join(ROOT, "shell", "target", "release", "bagidea-office-shell.exe");
+  const isMac = process.platform === "darwin";
+  const name = isMac ? "bagidea-office-shell" : "bagidea-office-shell.exe";
+  const exe = path.join(ROOT, "shell", "target", "release", name);
   return fs.existsSync(exe) ? exe : null;
 }
 

--- a/cli/find-shell.js
+++ b/cli/find-shell.js
@@ -1,0 +1,29 @@
+// cli/find-shell.js — locate the native shell binary across platforms.
+// Extracted so it can be unit-tested without spawning the full CLI.
+
+const fs = require("fs");
+const path = require("path");
+
+/**
+ * Find the compiled shell binary.
+ * Tries release first, then debug as fallback.
+ *
+ * @param {string} root     — project root (where shell/ lives)
+ * @param {string} [platform] — process.platform override (for testing)
+ * @returns {string|null} absolute path to the binary, or null
+ */
+function findShellExe(root, platform) {
+  const p = platform || process.platform;
+  const isWindows = p === "win32";
+  const name = isWindows ? "bagidea-office-shell.exe" : "bagidea-office-shell";
+  const candidates = [
+    path.join(root, "shell", "target", "release", name),
+    path.join(root, "shell", "target", "debug", name),
+  ];
+  for (const exe of candidates) {
+    if (fs.existsSync(exe)) return exe;
+  }
+  return null;
+}
+
+module.exports = { findShellExe };

--- a/cli/tests/find-shell.test.js
+++ b/cli/tests/find-shell.test.js
@@ -1,0 +1,140 @@
+// cli/tests/find-shell.test.js — unit tests for findShellExe()
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const os = require("node:os");
+
+const { findShellExe } = require("../find-shell");
+
+// Create a temp dir that mimics the project structure
+function makeTempProject() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "bagidea-test-"));
+  const releaseDir = path.join(tmp, "shell", "target", "release");
+  const debugDir = path.join(tmp, "shell", "target", "debug");
+  fs.mkdirSync(releaseDir, { recursive: true });
+  fs.mkdirSync(debugDir, { recursive: true });
+  return { tmp, releaseDir, debugDir };
+}
+
+function cleanup(tmp) {
+  fs.rmSync(tmp, { recursive: true, force: true });
+}
+
+// --- macOS ---
+
+test("macOS: finds bagidea-office-shell (no .exe) in release", () => {
+  const { tmp, releaseDir } = makeTempProject();
+  const binary = path.join(releaseDir, "bagidea-office-shell");
+  fs.writeFileSync(binary, "fake binary");
+
+  const result = findShellExe(tmp, "darwin");
+  assert.equal(result, binary);
+
+  cleanup(tmp);
+});
+
+test("macOS: does NOT find bagidea-office-shell.exe", () => {
+  const { tmp, releaseDir } = makeTempProject();
+  // Only .exe exists — should NOT be found on macOS
+  fs.writeFileSync(path.join(releaseDir, "bagidea-office-shell.exe"), "fake");
+
+  const result = findShellExe(tmp, "darwin");
+  assert.equal(result, null);
+
+  cleanup(tmp);
+});
+
+test("macOS: falls back to debug build", () => {
+  const { tmp, debugDir } = makeTempProject();
+  const binary = path.join(debugDir, "bagidea-office-shell");
+  fs.writeFileSync(binary, "fake binary");
+
+  const result = findShellExe(tmp, "darwin");
+  assert.equal(result, binary);
+
+  cleanup(tmp);
+});
+
+test("macOS: prefers release over debug", () => {
+  const { tmp, releaseDir, debugDir } = makeTempProject();
+  const rel = path.join(releaseDir, "bagidea-office-shell");
+  const dbg = path.join(debugDir, "bagidea-office-shell");
+  fs.writeFileSync(rel, "release");
+  fs.writeFileSync(dbg, "debug");
+
+  const result = findShellExe(tmp, "darwin");
+  assert.equal(result, rel);
+
+  cleanup(tmp);
+});
+
+// --- Linux ---
+
+test("linux: finds bagidea-office-shell (no .exe) in release", () => {
+  const { tmp, releaseDir } = makeTempProject();
+  const binary = path.join(releaseDir, "bagidea-office-shell");
+  fs.writeFileSync(binary, "fake binary");
+
+  const result = findShellExe(tmp, "linux");
+  assert.equal(result, binary);
+
+  cleanup(tmp);
+});
+
+// --- Windows ---
+
+test("win32: finds bagidea-office-shell.exe in release", () => {
+  const { tmp, releaseDir } = makeTempProject();
+  const binary = path.join(releaseDir, "bagidea-office-shell.exe");
+  fs.writeFileSync(binary, "fake binary");
+
+  const result = findShellExe(tmp, "win32");
+  assert.equal(result, binary);
+
+  cleanup(tmp);
+});
+
+test("win32: does NOT find bagidea-office-shell without .exe", () => {
+  const { tmp, releaseDir } = makeTempProject();
+  // Only non-.exe exists — should NOT be found on Windows
+  fs.writeFileSync(path.join(releaseDir, "bagidea-office-shell"), "fake");
+
+  const result = findShellExe(tmp, "win32");
+  assert.equal(result, null);
+
+  cleanup(tmp);
+});
+
+test("win32: falls back to debug build", () => {
+  const { tmp, debugDir } = makeTempProject();
+  const binary = path.join(debugDir, "bagidea-office-shell.exe");
+  fs.writeFileSync(binary, "fake binary");
+
+  const result = findShellExe(tmp, "win32");
+  assert.equal(result, binary);
+
+  cleanup(tmp);
+});
+
+// --- Edge cases ---
+
+test("returns null when no binary exists", () => {
+  const { tmp } = makeTempProject();
+  // release and debug dirs exist but are empty
+
+  const result = findShellExe(tmp, "darwin");
+  assert.equal(result, null);
+
+  cleanup(tmp);
+});
+
+test("returns null when shell/target dirs don't exist at all", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "bagidea-test-empty-"));
+  // No shell/ directory at all
+
+  const result = findShellExe(tmp, "darwin");
+  assert.equal(result, null);
+
+  cleanup(tmp);
+});


### PR DESCRIPTION
## Problem

On macOS, `cargo build --release` produces `bagidea-office-shell` (no `.exe` extension).  
But `findShellExe()` in `cli/bagidea` is hardcoded to look for `bagidea-office-shell.exe`:

```js
const exe = path.join(ROOT, "shell", "target", "release", "bagidea-office-shell.exe");
```

This means `bagidea start` always fails on macOS with:
```
✗ shell exe not found — run cargo build --release in shell/
```

## Fix

Check `process.platform` and use the correct filename per OS:
- **macOS/Linux** → `bagidea-office-shell`
- **Windows** → `bagidea-office-shell.exe`

```js
const isMac = process.platform === "darwin";
const name = isMac ? "bagidea-office-shell" : "bagidea-office-shell.exe";
```

## Tested

- macOS 26.4.1, Rust build produces the binary at `shell/target/release/bagidea-office-shell` ✓
- After the fix, `findShellExe()` finds it and `bagidea start` proceeds ✓
