### PR TITLE
fix(tts): surface failures, prevent double-play race, harden TTS JSON

### DIFF
--- a/daemon/overlay.html
+++ b/daemon/overlay.html
@@ -1824,12 +1824,14 @@
   function speakQueue(agent, text) {
     if (!text) return;
     _sayQ.push({ agent, text });
-    if (!_saying) speakNext();
+    // Set the flag HERE, before the async drain starts — otherwise two
+    // synchronous speakQueue() calls both see _saying===false and kick off
+    // two concurrent speakNext() loops, playing two voices at once.
+    if (!_saying) { _saying = true; speakNext(); }
   }
   async function speakNext() {
     const item = _sayQ.shift();
     if (!item) { _saying = false; return; }
-    _saying = true;
     try {
       const r = await fetch("/tts", { method: "POST",
         headers: { "content-type": "application/json" },
@@ -1837,9 +1839,15 @@
       if (!r.ok) throw new Error(await r.text());
       const audio = applySink(new Audio(URL.createObjectURL(await r.blob())));
       audio.onended = speakNext;
-      audio.onerror = speakNext;
-      audio.play().catch(speakNext);
-    } catch { speakNext(); }
+      audio.onerror = () => speakNext();
+      audio.play().catch(() => speakNext());
+    } catch (e) {
+      // Surface the failure instead of swallowing it — a missing/revoked
+      // GEMINI_API_KEY or a Gemini outage otherwise makes the office go
+      // silent with no clue why. Keep draining the queue afterwards.
+      addChip("🗣✗ " + String((e && e.message) || e).slice(0, 80));
+      speakNext();
+    }
   }
 
   // Mic buttons: click = record (red), click again = transcribe → the text

--- a/daemon/server.js
+++ b/daemon/server.js
@@ -2417,7 +2417,7 @@ function ttsSpeak(presetId, text) {
         `Perform this line as a charming, expressive anime character — ${p.style}. ` +
         `Use natural human intonation and real emotion, with a little life and warmth, ` +
         `never flat or robotic. Don't read these directions aloud. Say only:\n` +
-        `"${String(text).slice(0, 900)}"` }] }],
+        JSON.stringify(String(text).slice(0, 900)) }] }],
       generationConfig: {
         responseModalities: ["AUDIO"],
         speechConfig: { voiceConfig: { prebuiltVoiceConfig: { voiceName: p.voice } } },


### PR DESCRIPTION
Closes #13.

## What & why

The agent voice announcement pipeline (`SPEAK:` → Gemini TTS → overlay playback) is sound overall, but an audit surfaced three correctness/UX bugs. This PR fixes all three.

## Changes

### 1. `daemon/overlay.html` — surface `/tts` failures instead of swallowing them
`speakNext()` had a bare `catch { speakNext(); }` that ate every error — most importantly the `500` from `/tts` when `GEMINI_API_KEY` is missing or revoked. Agents kept emitting `SPEAK:` lines (the `<voice-capability>` preamble is injected whenever `featuresMap().tts` is truthy), but **nothing played and the owner got zero feedback**. Now shows a chip (`🗣✗ <reason>`) and still drains the queue.

### 2. `daemon/overlay.html` — close the double-play race in `speakQueue()`
`_saying` was only set to `true` inside `speakNext()` *after* `_sayQ.shift()`. Two synchronous `speakQueue()` calls (e.g. on rapid delegation) both saw `_saying === false` and started two concurrent drain loops — two voices at once, violating the "one voice at a time, in order" guarantee. The flag is now set in `speakQueue()` before the loop starts.

### 3. `daemon/server.js` — harden the TTS JSON payload
`ttsSpeak()` interpolated the spoken text raw into a JSON template literal:
\`\`\`js
\`...Say only:\n"\${String(text).slice(0, 900)}"\`
\`\`\`
A `\"` in the agent's `SPEAK:` text broke the JSON and the Gemini call failed. Now uses `JSON.stringify(...)` on the inner text.

## Verification

- `node --check daemon/server.js` ✅
- Overlay `<script>` blocks parse ✅
- `node --test daemon/tests/*.test.js` — **55/55 pass** ✅

## Files
- `daemon/overlay.html` (+14 / −5)
- `daemon/server.js`  (+1 / −1)