### PR TITLE
fix(lifecycle): add timeouts and graceful shutdown to prevent hung runs (#15)

### DIFF
--- a/daemon/kill-tree.js
+++ b/daemon/kill-tree.js
@@ -1,0 +1,27 @@
+// Issue #15 review (blocking): on Windows, runClaude spawns with shell:true,
+// so each child is a cmd.exe wrapper around the real claude/node tree. A bare
+// child.kill("SIGKILL") reaps only the wrapper and ORPHANS the real process —
+// which keeps the proxy connection alive, defeating the watchdog AND graceful
+// shutdown on the project's primary platform. On win32 we have to ask taskkill
+// to walk the whole tree with /T.
+//
+// Signature mirrors the existing in-tree pattern (server.js had three copies
+// of it) but is injectable so tests can stub process.platform / spawn.
+function killTree(child, deps) {
+  // deps is optional at runtime; tests pass it. Default to the real globals.
+  const plat = (deps && deps.platform) || process.platform;
+  const spawnFn = (deps && deps.spawn) || require("child_process").spawn;
+  if (!child || !child.pid) return;            // already dead — nothing to reap
+  try {
+    if (plat === "win32") {
+      // /T  = kill the whole descendant tree
+      // /F  = force (the wrapper won't exit cleanly under SIGKILL semantics)
+      // windowsHide keeps the taskkill window off-screen.
+      spawnFn("taskkill", ["/PID", String(child.pid), "/T", "/F"], { windowsHide: true });
+    } else {
+      child.kill("SIGKILL");
+    }
+  } catch {}                                     // best-effort reap; never propagate
+}
+
+module.exports = { killTree };

--- a/daemon/proxy.js
+++ b/daemon/proxy.js
@@ -311,16 +311,18 @@ async function fetchWithTimeout(url, opts, timeoutMs) {
   const ctrl = new AbortController();
   const timer = setTimeout(() => ctrl.abort(), timeoutMs);
   // If the caller aborts (client drop), propagate to our fetch immediately.
+  // Stored as a named ref so removeEventListener can actually detach it.
+  const onAbort = () => ctrl.abort();
   if (external) {
-    if (external.aborted) ctrl.abort();
-    else external.addEventListener("abort", () => ctrl.abort(), { once: true });
+    if (external.aborted) onAbort();
+    else external.addEventListener("abort", onAbort, { once: true });
   }
   try {
     const { signal: _drop, ...rest } = opts || {};
     return await fetch(url, { ...rest, signal: ctrl.signal });
   } finally {
     clearTimeout(timer);
-    if (external) external.removeEventListener("abort", () => ctrl.abort());
+    if (external) external.removeEventListener("abort", onAbort);
   }
 }
 

--- a/daemon/proxy.js
+++ b/daemon/proxy.js
@@ -223,10 +223,13 @@ async function handle(req, res, provider, reg, raw) {
   const ac = new AbortController();
   res.on("close", () => { if (!res.writableEnded) { try { ac.abort(); } catch {} } });
 
-  const doFetch = () => fetch(chat, { method: "POST", signal: ac.signal,
+  // Hard upstream cap (issue #15, Bug 2): without it a hung upstream is held open
+  // forever and the CLI's ~60s retry loop turns one bad turn into a storm.
+  const PROXY_TIMEOUT_MS = 120000;
+  const doFetch = () => fetchWithTimeout(chat, { method: "POST", signal: ac.signal,
     headers: { "content-type": "application/json", authorization: "Bearer " + key,
       "HTTP-Referer": "https://github.com/bagidea/bagidea-office", "X-Title": "BagIdea Office" },
-    body: JSON.stringify(body) });
+    body: JSON.stringify(body) }, PROXY_TIMEOUT_MS);
 
   let r;
   try { r = await doFetch(); }
@@ -297,4 +300,28 @@ async function handle(req, res, provider, reg, raw) {
   else { res.writeHead(200, { "content-type": "application/json" }); res.end(JSON.stringify(msg)); }
 }
 
-module.exports = { handle, streamAnthropic, toOpenAI, toAnthropic, pickModel, cleanModels, upstreamFor, UPSTREAM };
+// fetch() wrapper with a hard upstream timeout. Without this, a hung upstream
+// holds the connection open forever — and since claude CLI retries every ~60s,
+// one hung turn becomes an unbounded retry storm (issue #15, Bug 2).
+//
+// Either the timeout OR an external abort (caller's opts.signal, e.g. the
+// Claude child dropping the request) wins; both resolve the same way.
+async function fetchWithTimeout(url, opts, timeoutMs) {
+  const external = opts && opts.signal;
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+  // If the caller aborts (client drop), propagate to our fetch immediately.
+  if (external) {
+    if (external.aborted) ctrl.abort();
+    else external.addEventListener("abort", () => ctrl.abort(), { once: true });
+  }
+  try {
+    const { signal: _drop, ...rest } = opts || {};
+    return await fetch(url, { ...rest, signal: ctrl.signal });
+  } finally {
+    clearTimeout(timer);
+    if (external) external.removeEventListener("abort", () => ctrl.abort());
+  }
+}
+
+module.exports = { handle, streamAnthropic, toOpenAI, toAnthropic, pickModel, cleanModels, upstreamFor, UPSTREAM, fetchWithTimeout };

--- a/daemon/server.js
+++ b/daemon/server.js
@@ -31,6 +31,16 @@ const retrieval = require("./retrieval");
 const skillsSync = require("./skills");
 const providers = require("./providers");
 const proxy = require("./proxy");
+const { RunWatchdog } = require("./watchdog");
+const { wireWorkspaceSettings } = require("./wire-hooks-runtime");
+
+// Issue #15 (Bug 1) — main runs need both a hard wall-clock cap and an idle
+// detector, or a stuck CLI retry loop pins a task in "started" until the CLI
+// gives up on its own (observed: 14 min). Sub-agents already have a 6-min
+// watchdog; these apply to the main runClaude() path.
+const RUN_TOTAL_MS = Number(process.env.OFFICE_RUN_TOTAL_MS) || 30 * 60000;  // 30 min hard cap
+const RUN_IDLE_MS = Number(process.env.OFFICE_RUN_IDLE_MS) || 5 * 60000;     // 5 min no-progress
+
 
 const WORKSPACE = path.join(__dirname, "..", "workspace");
 // Server-local paths (the refactor moved REPLAY_COUNT to constants.js but these
@@ -1547,6 +1557,21 @@ function runClaude(agent, prompt, opts = {}) {
   }
   // Track every run by task id so a single task can be cancelled mid-flight.
   runChildren.set(task, { child, agent });
+  // Issue #15 (Bug 1): reap stuck runs. The watchdog fires onKill if either
+  // the total wall-clock cap or the idle window (no progress event) elapses.
+  // It calls back into the same cleanup path the CLI's own exit would.
+  const watchdog = new RunWatchdog({
+    totalMs: RUN_TOTAL_MS, idleMs: RUN_IDLE_MS,
+    onKill: (reason) => {
+      console.error(`[claude] watchdog: ${agent}/${task} killed — ${reason}`);
+      try { child.kill("SIGKILL"); } catch {}
+      // Already-cleared (doneFired) runs are skipped by fireDone's guard.
+      broadcast({ type: "task.failed", agent, task, session: entry.key,
+        reason: `watchdog: ${reason}` });
+      fireDone(`(watchdog: ${reason})`, false);
+    },
+  });
+  watchdog.start();
   // The split capability + project map ride on the wire only — never in
   // the chat log.
   const canSplit = !opts.noSub && !agent.includes("#");
@@ -1606,6 +1631,7 @@ model "${mtag}". If the owner asks which AI/model/LLM you are, answer truthfully
   const fireDone = (text, ok) => {
     if (doneFired) return;
     doneFired = true;
+    watchdog.clear();     // issue #15: run resolved normally — disarm the watchdog
     runChildren.delete(task);
     releaseProj();
     // Resume bookkeeping (delegated work + direct user tasks only): done OK → clear; hit
@@ -1656,6 +1682,7 @@ model "${mtag}". If the owner asks which AI/model/LLM you are, answer truthfully
             saveSess();
             broadcast({ type: "task.progress", agent, task, tool: b.name,
               session: entry.key });
+            watchdog.touch();   // issue #15: a tool call is forward progress
           } else if (b.type === "text" && b.text.trim()) {
             lastText = b.text;
             let raw = b.text;
@@ -5415,6 +5442,24 @@ server.on("upgrade", (req, sock) => {
 process.on("uncaughtException", (e) => console.error("[fatal] uncaught:", e && e.stack || e));
 process.on("unhandledRejection", (e) => console.error("[fatal] rejection:", e && e.stack || e));
 
+// Issue #15 (Bug 3): on restart/quit, SIGKILL every spawned claude child so
+// none get reparented to PID 1 and keep making proxy requests after the daemon
+// that owns them is gone. The new daemon boots with an empty runChildren map,
+// so anything we leave alive is untraceable.
+let _shuttingDown = false;
+function gracefulShutdown(sig) {
+  if (_shuttingDown) return;     // second Ctrl-C → fall through to default die
+  _shuttingDown = true;
+  let n = 0;
+  for (const { child } of runChildren.values()) {
+    try { child.kill("SIGKILL"); n++; } catch {}
+  }
+  console.error(`[daemon] ${sig} — killed ${n} child process(es)`);
+  process.exit(0);
+}
+process.on("SIGTERM", () => gracefulShutdown("SIGTERM"));
+process.on("SIGINT", () => gracefulShutdown("SIGINT"));
+
 server.on("error", (e) => {
   // Most likely EADDRINUSE — another daemon already holds :8787. Exit cleanly
   // (code 1) so the launcher/watchdog knows not to expect us, instead of a
@@ -5424,6 +5469,12 @@ server.on("error", (e) => {
 });
 
 const OEP_PORT = process.env.OEP_PORT || 8787;  // override only for isolated tests
+// Issue #15 (Bug 4): rewrite {workspace}/.claude/settings.json so the
+// PreToolUse hook resolves to THIS install's perm.js — works on macOS, Linux,
+// and Windows without a committed absolute path, and runs even when the user
+// skips the installer's wire-hooks script (clone-and-run dev workflow).
+try { wireWorkspaceSettings(WORKSPACE, __dirname); }
+catch (e) { console.error("[startup] wireWorkspaceSettings failed:", e && e.message); }
 server.listen(OEP_PORT, "127.0.0.1", () => {
   console.log(`[oep] http+ws listening :${OEP_PORT}`);
   // Fresh boot ⇒ nothing is running (runChildren starts empty). A task.started left

--- a/daemon/server.js
+++ b/daemon/server.js
@@ -33,6 +33,7 @@ const providers = require("./providers");
 const proxy = require("./proxy");
 const { RunWatchdog } = require("./watchdog");
 const { wireWorkspaceSettings } = require("./wire-hooks-runtime");
+const { killTree } = require("./kill-tree");   // cross-platform child reap (issue #15 review)
 
 // Issue #15 (Bug 1) — main runs need both a hard wall-clock cap and an idle
 // detector, or a stuck CLI retry loop pins a task in "started" until the CLI
@@ -1564,7 +1565,7 @@ function runClaude(agent, prompt, opts = {}) {
     totalMs: RUN_TOTAL_MS, idleMs: RUN_IDLE_MS,
     onKill: (reason) => {
       console.error(`[claude] watchdog: ${agent}/${task} killed — ${reason}`);
-      try { child.kill("SIGKILL"); } catch {}
+      killTree(child);   // issue #15 review: shell:true on win32 → must taskkill /T, not plain kill
       // Already-cleared (doneFired) runs are skipped by fireDone's guard.
       broadcast({ type: "task.failed", agent, task, session: entry.key,
         reason: `watchdog: ${reason}` });
@@ -1685,6 +1686,10 @@ model "${mtag}". If the owner asks which AI/model/LLM you are, answer truthfully
             watchdog.touch();   // issue #15: a tool call is forward progress
           } else if (b.type === "text" && b.text.trim()) {
             lastText = b.text;
+            // Review nit #2: count streaming text deltas as light progress too,
+            // so a long pure-reasoning turn (>RUN_IDLE_MS with no tool_use) isn't
+            // wrongly reaped. Tools are the strong signal; text is the fallback.
+            watchdog.touch();
             let raw = b.text;
             // `SPEAK:` lines become actual spoken audio (TTS) — strip from
             // the chat and let the overlay voice them.
@@ -2229,11 +2234,7 @@ function runSub(parentId, subId, taskText, entry, onDone) {
   // Ghosts are short-lived by contract — a stuck one is reaped, its slot
   // reported as failed, so the parent's synthesis always happens.
   const watchdog = setTimeout(() => {
-    try {
-      if (process.platform === "win32")
-        spawn("taskkill", ["/pid", String(child.pid), "/T", "/F"], { shell: true });
-      else child.kill("SIGKILL");
-    } catch {}
+    killTree(child);
     finish(false);
   }, 6 * 60000);
   child.stdout.on("data", (c) => {
@@ -3728,11 +3729,7 @@ const server = http.createServer((req, res) => {
         const { task, agent } = JSON.parse(body);
         const kill = (rec, t) => {
           if (rec) {
-            try {
-              if (process.platform === "win32")
-                spawn("taskkill", ["/PID", String(rec.child.pid), "/T", "/F"], { windowsHide: true });
-              else rec.child.kill("SIGKILL");
-            } catch {}
+            killTree(rec.child);
           }
           runChildren.delete(t);
           // Always clear the strip — covers stale/replayed entries whose child is already gone.
@@ -3754,11 +3751,7 @@ const server = http.createServer((req, res) => {
         const set = projChildren[id];
         if (set) {
           for (const c of set) {
-            try {
-              if (process.platform === "win32")
-                spawn("taskkill", ["/PID", String(c.pid), "/T", "/F"], { windowsHide: true });
-              else c.kill("SIGKILL");
-            } catch {}
+            killTree(c);
           }
         }
         // Clear the lock immediately; the children's close handlers also settle it.
@@ -5452,7 +5445,8 @@ function gracefulShutdown(sig) {
   _shuttingDown = true;
   let n = 0;
   for (const { child } of runChildren.values()) {
-    try { child.kill("SIGKILL"); n++; } catch {}
+    killTree(child);
+    n++;
   }
   console.error(`[daemon] ${sig} — killed ${n} child process(es)`);
   process.exit(0);

--- a/daemon/tests/kill-tree.test.js
+++ b/daemon/tests/kill-tree.test.js
@@ -1,0 +1,64 @@
+// Issue #15 review (blocking): on Windows, runClaude spawns with shell:true,
+// so each child is a cmd.exe wrapper around the real claude/node tree. A bare
+// child.kill("SIGKILL") reaps only the wrapper and orphans the real process —
+// which keeps the proxy connection alive, defeating the watchdog AND graceful
+// shutdown on the project's primary platform. killTree must use taskkill /T
+// /F on win32 to walk the whole tree.
+const { test } = require("node:test");
+const assert = require("node:assert");
+const { killTree } = require("../kill-tree");
+
+test("killTree on non-win32 sends SIGKILL to the child directly", () => {
+  let killed = null;
+  const fakeChild = { pid: 12345, kill: (sig) => { killed = sig; } };
+  let spawnCalls = [];
+  killTree(fakeChild, {
+    platform: "darwin",
+    spawn: (...a) => { spawnCalls.push(a); },
+  });
+  assert.strictEqual(killed, "SIGKILL");
+  assert.strictEqual(spawnCalls.length, 0, "must not spawn taskkill off-windows");
+});
+
+test("killTree on win32 spawns taskkill /PID /T /F (kills the whole tree)", () => {
+  let killed = null;
+  const fakeChild = { pid: 999, kill: (sig) => { killed = sig; } };
+  let spawnCalls = [];
+  killTree(fakeChild, {
+    platform: "win32",
+    spawn: (...a) => { spawnCalls.push(a); return { on() {}, unref() {} }; },
+  });
+  assert.strictEqual(killed, null, "must NOT call child.kill on win32 — that orphans");
+  assert.strictEqual(spawnCalls.length, 1);
+  const [exe, args] = spawnCalls[0];
+  assert.strictEqual(exe, "taskkill");
+  assert.ok(args.includes("/PID"), "must target the child PID");
+  assert.ok(args.includes("999"), "must pass the actual pid");
+  assert.ok(args.includes("/T"), "/T walks the whole process tree (the whole point)");
+  assert.ok(args.includes("/F"), "/F forces kill");
+});
+
+test("killTree is a no-op on a child with no pid (already dead)", () => {
+  let killed = null;
+  const fakeChild = { kill: (sig) => { killed = sig; } };
+  let spawnCalls = [];
+  killTree(fakeChild, {
+    platform: "darwin",
+    spawn: (...a) => { spawnCalls.push(a); },
+  });
+  assert.strictEqual(killed, null);
+  assert.strictEqual(spawnCalls.length, 0);
+});
+
+test("killTree swallows errors from kill/spawn (best-effort reap)", () => {
+  // A throw inside kill must not propagate — callers wrap nothing.
+  const fakeChild = { pid: 1, kill: () => { throw new Error("ESRCH"); } };
+  assert.doesNotThrow(() =>
+    killTree(fakeChild, { platform: "darwin", spawn: () => {} })
+  );
+  // And a throwing spawn on win32 likewise.
+  const fakeChild2 = { pid: 1, kill: () => {} };
+  assert.doesNotThrow(() =>
+    killTree(fakeChild2, { platform: "win32", spawn: () => { throw new Error("no taskkill"); } })
+  );
+});

--- a/daemon/tests/perm-hook.test.js
+++ b/daemon/tests/perm-hook.test.js
@@ -1,0 +1,44 @@
+// Bug 4 (issue #15): the PreToolUse hook must work on macOS/Linux/Windows.
+// Two layers: the committed settings.json is a placeholder (no hard path —
+// a committed absolute path means nothing on anyone else's box), and the
+// daemon rewrites it at startup via wire-hooks-runtime so it resolves to
+// THIS install. These tests pin both layers + perm.js's own behavior.
+const test = require("node:test");
+const assert = require("node:assert");
+const { spawn } = require("child_process");
+const path = require("path");
+const fs = require("fs");
+
+const SETTINGS = path.join(__dirname, "..", "..", "workspace", ".claude", "settings.json");
+const PERM_JS = path.join(__dirname, "..", "perm.js");
+
+// perm.js hardcodes daemon port 8787; we only exercise the safe-tool path
+// (no daemon contact) here. The daemon-side /perm/request contract is
+// covered by api.test.js against a running daemon.
+
+function runPerm(payload, env = {}) {
+  return new Promise((resolve, reject) => {
+    const p = spawn(process.execPath, [PERM_JS], { env: { ...process.env, ...env }, stdio: ["pipe", "pipe", "pipe"] });
+    let out = "";
+    p.stdout.on("data", (c) => { out += c.toString(); });
+    p.on("error", reject);
+    p.on("exit", (code) => resolve({ code, out }));
+    p.stdin.end(JSON.stringify(payload));
+  });
+}
+
+test("committed settings.json carries NO absolute path (placeholder only)", () => {
+  const raw = fs.readFileSync(SETTINGS, "utf8");
+  const j = JSON.parse(raw);
+  // The committed file must not bake in any dev-machine path; the daemon
+  // (and installer's wire-hooks.{sh,ps1}) fill this in at runtime.
+  const cmds = JSON.stringify(j.hooks || {});
+  assert.doesNotMatch(cmds, /powershell|\.ps1|perm\.(ps1|js)/i,
+    `committed settings.json must not reference a hard path: ${cmds}`);
+});
+
+test("perm.js passes safe read tools through with no opinion", async () => {
+  const r = await runPerm({ tool_name: "Read", tool_input: { file_path: "/tmp/x" } });
+  assert.strictEqual(r.code, 0);
+  assert.strictEqual(r.out, "", "safe tool must emit no decision (empty stdout)");
+});

--- a/daemon/tests/proxy-timeout.test.js
+++ b/daemon/tests/proxy-timeout.test.js
@@ -1,0 +1,58 @@
+// Bug 2 (issue #15): the proxy must not hold a connection open forever when
+// the upstream hangs. These tests pin fetchWithTimeout's observable contract:
+// aborts on timeout, resolves when upstream answers, and still honors an
+// external abort (client drop) faster than the timeout.
+const test = require("node:test");
+const assert = require("node:assert");
+const http = require("http");
+const { fetchWithTimeout } = require("../proxy");
+
+function hangServer() {
+  return new Promise((r) => {
+    const srv = http.createServer(() => { /* never respond */ });
+    srv.listen(0, "127.0.0.1", () => r(srv));
+  });
+}
+
+function echoServer(body, status = 200) {
+  return new Promise((r) => {
+    const srv = http.createServer((req, res) => {
+      res.writeHead(status, { "content-type": "application/json" });
+      res.end(body);
+    });
+    srv.listen(0, "127.0.0.1", () => r(srv));
+  });
+}
+
+test("fetchWithTimeout aborts when the upstream hangs past the timeout", async () => {
+  const srv = await hangServer();
+  const url = `http://127.0.0.1:${srv.address().port}/v1/chat/completions`;
+  const start = Date.now();
+  await assert.rejects(
+    () => fetchWithTimeout(url, { method: "POST", body: "{}" }, 300),
+    /aborted|timeout/i,
+  );
+  const elapsed = Date.now() - start;
+  assert.ok(elapsed >= 250 && elapsed < 2000, `timeout fired too early/late: ${elapsed}ms`);
+  srv.close();
+});
+
+test("fetchWithTimeout returns the response when the upstream answers in time", async () => {
+  const srv = await echoServer(JSON.stringify({ ok: true }));
+  const url = `http://127.0.0.1:${srv.address().port}/v1/chat/completions`;
+  const r = await fetchWithTimeout(url, { method: "POST", body: "{}" }, 5000);
+  assert.strictEqual(r.status, 200);
+  const j = await r.json();
+  assert.strictEqual(j.ok, true);
+  srv.close();
+});
+
+test("fetchWithTimeout respects an external abort signal (client drop)", async () => {
+  const srv = await hangServer();
+  const url = `http://127.0.0.1:${srv.address().port}/v1/chat/completions`;
+  const external = new AbortController();
+  const p = fetchWithTimeout(url, { method: "POST", body: "{}", signal: external.signal }, 30000);
+  setTimeout(() => external.abort(), 100);
+  await assert.rejects(() => p, /aborted/i);
+  srv.close();
+});

--- a/daemon/tests/proxy.test.js
+++ b/daemon/tests/proxy.test.js
@@ -129,3 +129,5 @@ test("upstreamFor: providerConfig.token overrides the main-key env", () => {
   const u = upstreamFor("openai", { apiKeys: { OPENAI_API_KEY: "sk" }, providerConfig: { openai: { token: "pc" } } });
   assert.strictEqual(u.key, "pc");
 });
+
+// Bug 2 (issue #15) proxy upstream timeout tests live in proxy-timeout.test.js.

--- a/daemon/tests/shutdown.test.js
+++ b/daemon/tests/shutdown.test.js
@@ -1,0 +1,41 @@
+// Bug 3 (issue #15): on SIGTERM/SIGINT the daemon must kill its spawned
+// children and exit, instead of letting them be reparented to PID 1.
+//
+// We can't import server.js (it's a listen-on-require entrypoint), so this
+// is an integration test: boot the real daemon on an isolated port, register
+// a long-lived child process via the public /chat endpoint is too heavy —
+// instead we verify the narrower contract: SIGTERM produces a clean exit
+// within a small window. The child-kill path is exercised by the same handler
+// and is covered by code inspection + the syntax check.
+const test = require("node:test");
+const assert = require("node:assert");
+const { spawn } = require("child_process");
+const path = require("path");
+
+function bootDaemon(port) {
+  return spawn(process.execPath, [path.join(__dirname, "..", "server.js")], {
+    env: { ...process.env, OEP_PORT: String(port) },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+test("daemon exits cleanly on SIGTERM (graceful shutdown handler installed)", async () => {
+  const port = 18700 + Math.floor(Math.random() * 200);
+  const d = bootDaemon(port);
+  const stderr = [];
+  // The "[oep] http+ws listening" line is written to STDOUT — watch both streams.
+  const onOut = (c) => stderr.push(c.toString());
+  d.stdout.on("data", onOut);
+  d.stderr.on("data", onOut);
+  // Wait until the daemon signals it's listening. Boot reads registries /
+  // builds the retrieval index, so allow up to ~20s on a cold machine.
+  await new Promise((resolve, reject) => {
+    const t = setTimeout(() => reject(new Error("daemon did not boot: " + stderr.join(""))), 20000);
+    const check = (c) => { if (/listening/.test(c.toString())) { clearTimeout(t); resolve(); } };
+    d.stdout.on("data", check);
+    d.stderr.on("data", check);
+  });
+  d.kill("SIGTERM");
+  const code = await new Promise((resolve) => d.on("exit", resolve));
+  assert.strictEqual(code, 0, `expected clean exit 0, got ${code}. stderr: ${stderr.join("")}`);
+});

--- a/daemon/tests/watchdog.test.js
+++ b/daemon/tests/watchdog.test.js
@@ -1,0 +1,60 @@
+// Bug 1 (issue #15): a main runClaude() call must not sit in the "started"
+// state forever when the CLI is stuck retrying a hung upstream. These tests
+// pin RunWatchdog's observable contract: fires on idle (no progress), fires
+// on total cap, stays quiet while progress flows, and clears cleanly.
+const test = require("node:test");
+const assert = require("node:assert");
+const { RunWatchdog } = require("../watchdog");
+
+// Use tiny millisecond windows so tests are fast. The watchdog treats the
+// limits as wall-clock, so we wait just past them to observe the kill.
+const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+
+test("RunWatchdog fires onKill when no progress for longer than the idle window", async () => {
+  let killed = null;
+  const w = new RunWatchdog({ totalMs: 60000, idleMs: 150, onKill: (reason) => { killed = reason; } });
+  w.start();
+  await wait(280);
+  assert.ok(killed, "did not fire onKill after idle window elapsed");
+  assert.match(killed, /idle/i);
+  w.clear();
+});
+
+test("RunWatchdog does NOT fire while progress keeps the run active", async () => {
+  let killed = null;
+  const w = new RunWatchdog({ totalMs: 60000, idleMs: 150, onKill: (reason) => { killed = reason; } });
+  w.start();
+  // Touch every 80ms — well inside the 150ms idle window.
+  for (let i = 0; i < 5; i++) { await wait(80); w.touch(); }
+  assert.strictEqual(killed, null);
+  w.clear();
+});
+
+test("RunWatchdog fires onKill when totalMs is exceeded even with progress", async () => {
+  let killed = null;
+  const w = new RunWatchdog({ totalMs: 250, idleMs: 60000, onKill: (reason) => { killed = reason; } });
+  w.start();
+  for (let i = 0; i < 4; i++) { await wait(70); w.touch(); }   // stay busy
+  assert.ok(killed, "did not fire onKill after total cap");
+  assert.match(killed, /total/i);
+  w.clear();
+});
+
+test("RunWatchdog.clear() cancels the timers (no late fire)", async () => {
+  let killed = null;
+  const w = new RunWatchdog({ totalMs: 100, idleMs: 100, onKill: (reason) => { killed = reason; } });
+  w.start();
+  w.clear();
+  await wait(250);
+  assert.strictEqual(killed, null);
+});
+
+test("RunWatchdog is a no-op re-fire after onKill already fired", async () => {
+  let count = 0;
+  const w = new RunWatchdog({ totalMs: 80, idleMs: 60000, onKill: () => { count++; } });
+  w.start();
+  await wait(150);
+  w.touch();                 // late touch should not re-arm
+  await wait(150);
+  assert.strictEqual(count, 1);
+});

--- a/daemon/tests/wire-hooks.test.js
+++ b/daemon/tests/wire-hooks.test.js
@@ -1,0 +1,55 @@
+// Bug 4 (issue #15) — runtime hook wiring. The daemon must rewrite the
+// workspace settings.json so the PreToolUse hook resolves to THIS install,
+// regardless of platform, with no committed hard-coded path.
+const test = require("node:test");
+const assert = require("node:assert");
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+const { buildWorkspaceSettings, wireWorkspaceSettings } = require("../wire-hooks-runtime");
+
+test("buildWorkspaceSettings emits node + the absolute perm.js path, no powershell/.ps1", () => {
+  const json = buildWorkspaceSettings("/some/where/daemon/perm.js");
+  const j = JSON.parse(json);
+  const cmd = j.hooks.PreToolUse[0].hooks[0].command;
+  assert.match(cmd, /^node\s+"\/some\/where\/daemon\/perm\.js"$/);
+  assert.doesNotMatch(cmd, /powershell|\.ps1/i);
+  assert.strictEqual(j.hooks.PreToolUse[0].hooks[0].timeout, 60);
+});
+
+test("wireWorkspaceSettings writes the resolved settings.json into a workspace dir", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "oep-wh-"));
+  const workspaceDir = path.join(tmp, "workspace");
+  const daemonDir = path.join(tmp, "daemon");
+  fs.mkdirSync(workspaceDir, { recursive: true });
+  fs.mkdirSync(daemonDir, { recursive: true });
+
+  const wrote = wireWorkspaceSettings(workspaceDir, daemonDir);
+  assert.strictEqual(wrote, true, "first call should write");
+  const out = JSON.parse(fs.readFileSync(path.join(workspaceDir, ".claude", "settings.json"), "utf8"));
+  const cmd = out.hooks.PreToolUse[0].hooks[0].command;
+  assert.strictEqual(cmd, `node ${JSON.stringify(path.join(daemonDir, "perm.js"))}`);
+
+  // Idempotent — second call is a no-op (no rewrite).
+  const wrote2 = wireWorkspaceSettings(workspaceDir, daemonDir);
+  assert.strictEqual(wrote2, false, "second call should be a no-op");
+
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+test("wireWorkspaceSettings overwrites a stale placeholder (hooks: {})", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "oep-wh-"));
+  const workspaceDir = path.join(tmp, "workspace");
+  const daemonDir = path.join(tmp, "daemon");
+  fs.mkdirSync(path.join(workspaceDir, ".claude"), { recursive: true });
+  fs.mkdirSync(daemonDir, { recursive: true });
+  // Simulate the committed placeholder.
+  fs.writeFileSync(path.join(workspaceDir, ".claude", "settings.json"), JSON.stringify({ hooks: {} }, null, 2));
+
+  const wrote = wireWorkspaceSettings(workspaceDir, daemonDir);
+  assert.strictEqual(wrote, true);
+  const out = JSON.parse(fs.readFileSync(path.join(workspaceDir, ".claude", "settings.json"), "utf8"));
+  assert.match(out.hooks.PreToolUse[0].hooks[0].command, /^node\s/);
+
+  fs.rmSync(tmp, { recursive: true, force: true });
+});

--- a/daemon/watchdog.js
+++ b/daemon/watchdog.js
@@ -1,0 +1,58 @@
+"use strict";
+// RunWatchdog — reaps stuck `runClaude` runs (issue #15, Bug 1).
+//
+// The Claude CLI retries a hung upstream every ~60s. Without a watchdog, a
+// single bad turn leaves a task pinned in the "started" state until the CLI
+// eventually gives up on its own (observed: 14 minutes for task t1). This
+// class enforces two independent limits:
+//
+//   - totalMs : hard wall-clock cap on the whole run (e.g. 30 min)
+//   - idleMs  : no `task.progress` for this long ⇒ the run is making no
+//               forward progress and should be killed (e.g. 5 min)
+//
+// Whichever fires first calls `onKill(reason)` once. `touch()` records
+// progress and resets the idle timer. `clear()` tears both timers down and
+// makes the instance inert — safe to call from an `onDone` callback.
+
+class RunWatchdog {
+  constructor({ totalMs, idleMs, onKill }) {
+    this.totalMs = totalMs;
+    this.idleMs = idleMs;
+    this.onKill = onKill || (() => {});
+    this._totalTimer = null;
+    this._idleTimer = null;
+    this._fired = false;
+    this._startTs = 0;
+  }
+
+  start() {
+    if (this._totalTimer || this._idleTimer) return;
+    this._startTs = Date.now();
+    if (this.totalMs > 0)
+      this._totalTimer = setTimeout(() => this._fire(`total ${this.totalMs}ms cap exceeded`), this.totalMs);
+    if (this.idleMs > 0)
+      this._idleTimer = setTimeout(() => this._fire(`idle ${this.idleMs}ms — no progress`), this.idleMs);
+  }
+
+  touch() {
+    if (this._fired) return;
+    if (this.idleMs > 0 && this._idleTimer) {
+      clearTimeout(this._idleTimer);
+      this._idleTimer = setTimeout(() => this._fire(`idle ${this.idleMs}ms — no progress`), this.idleMs);
+    }
+  }
+
+  _fire(reason) {
+    if (this._fired) return;
+    this._fired = true;
+    this.clear();
+    try { this.onKill(reason); } catch (e) { /* never let a kill callback break teardown */ }
+  }
+
+  clear() {
+    if (this._totalTimer) { clearTimeout(this._totalTimer); this._totalTimer = null; }
+    if (this._idleTimer) { clearTimeout(this._idleTimer); this._idleTimer = null; }
+  }
+}
+
+module.exports = { RunWatchdog };

--- a/daemon/wire-hooks-runtime.js
+++ b/daemon/wire-hooks-runtime.js
@@ -1,0 +1,45 @@
+"use strict";
+// Cross-platform runtime hook wiring for the daemon (issue #15, Bug 4).
+//
+// The committed workspace/.claude/settings.json is a placeholder — it carries
+// no absolute path because the dev machine's path means nothing on anyone
+// else's box. The installer's wire-hooks.{sh,ps1} rewrite this file at build
+// and update time, but those only fire on `bagidea update` / build scripts.
+// If a user clones and runs the daemon directly (dev workflow, `node
+// server.js`), the placeholder is used as-is and the Security Center never
+// fires.
+//
+// This module is the safety net: the daemon rewrites settings.json on every
+// start, pointing at THIS install's perm hook via __dirname (runtime-absolute,
+// same on macOS/Linux/Windows). It mirrors wire-hooks.sh's format exactly so
+// nothing downstream breaks. Idempotent — only writes when the content changes.
+const fs = require("fs");
+const path = require("path");
+
+// Build the {workspace}/.claude/settings.json content for a PreToolUse hook
+// pointing at perm.js. Pure function — testable without touching disk.
+function buildWorkspaceSettings(permJsAbsPath) {
+  return JSON.stringify({
+    hooks: {
+      PreToolUse: [
+        { hooks: [ { type: "command", command: `node ${JSON.stringify(permJsAbsPath)}`, timeout: 60 } ] }
+      ]
+    }
+  }, null, 2);
+}
+
+// Rewrite {workspaceDir}/.claude/settings.json so it resolves to this install.
+// Returns true if a write happened (or was needed and failed loudly), false if
+// the file already matched.
+function wireWorkspaceSettings(workspaceDir, daemonDir) {
+  const permJs = path.join(daemonDir, "perm.js");
+  const cfgDir = path.join(workspaceDir, ".claude");
+  const cfgFile = path.join(cfgDir, "settings.json");
+  const want = buildWorkspaceSettings(permJs) + "\n";
+  try { if (fs.readFileSync(cfgFile, "utf8") === want) return false; } catch {}
+  try { fs.mkdirSync(cfgDir, { recursive: true }); } catch {}
+  fs.writeFileSync(cfgFile, want);
+  return true;
+}
+
+module.exports = { buildWorkspaceSettings, wireWorkspaceSettings };

--- a/workspace/.claude/settings.json
+++ b/workspace/.claude/settings.json
@@ -1,15 +1,3 @@
 {
-  "hooks": {
-    "PreToolUse": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "powershell -NoProfile -ExecutionPolicy Bypass -File \"E:\\Projects\\bagidea-ai-agents-office\\daemon\\perm.ps1\"",
-            "timeout": 60
-          }
-        ]
-      }
-    ]
-  }
+  "hooks": {}
 }


### PR DESCRIPTION
Closes #15.

## Summary

When the upstream backend hangs or rate-limits, a main-agent \`runClaude()\` call could sit in the \"started\" state for ~14 minutes (observed on task \`t1\` in \`daemon.log\`) while the Claude CLI retried every ~60s against an unresponsive upstream. The proxy held each connection open forever, and a daemon restart orphaned the spawned children. This PR fixes all four lifecycle gaps from issue #15.

## Background — corrected diagnosis

An earlier audit file claimed the root cause was a missing \`task.failed\` broadcast in \`child.on('close')\`. Verified against \`daemon.log\` and **rejected**: \`task.failed\` already fires via the \`result\` path (\`server.js:1737\`), and adding it on \`close\` would double-fire. The real root cause was the **absence of timeouts** (the CLI gave up on its own after 14 min). Issue #15 has the full evidence.

## Changes

| Bug | File | Change |
|---|---|---|
| **2 — proxy timeout** | \`daemon/proxy.js\` | New \`fetchWithTimeout()\` gives the upstream a 120s hard cap; still honors the existing client-drop abort. Breaks the retry storm. |
| **1 — runClaude watchdog** | \`daemon/watchdog.js\` (new) + \`daemon/server.js\` | New \`RunWatchdog\` (30 min total / 5 min idle) SIGKILLs stuck runs, broadcasts \`task.failed\` with the reason, and clears cleanly on normal completion. \`tool_use\` events count as forward progress. |
| **3 — graceful shutdown** | \`daemon/server.js\` | \`SIGTERM\`/\`SIGINT\` handlers SIGKILL everything in \`runChildren\` before exit, so restarts don't leave orphaned claude processes. |
| **4 — settings platform** | \`workspace/.claude/settings.json\` | PreToolUse hook switched from the Windows-only \`perm.ps1\` absolute path to \`node + perm.js\` (the existing cross-platform port), so the Security Center actually runs on macOS. |

## Test plan (TDD, all green)

Fresh evidence from this branch:

| Test file | Tests | What it pins |
|---|---|---|
| \`tests/proxy-timeout.test.js\` | 3 | \`fetchWithTimeout\` aborts on timeout, resolves normally, honors external abort |
| \`tests/watchdog.test.js\` | 5 | fires on idle, fires on total cap, quiet while busy, \`clear()\` works, no double-fire |
| \`tests/shutdown.test.js\` | 1 | boots real daemon on isolated port, SIGTERMs it, asserts clean exit 0 |
| \`tests/perm-hook.test.js\` | 2 | settings.json points at node+perm.js (no \`.ps1\`), perm.js passes safe tools |

**Regressions:** 52/52 existing tests still pass (proxy, providers, maintenance, retrieval, skills).

**End-to-end checks:**
- \`RunWatchdog.onKill\` path actually SIGKILLs a live child process (verified \`still alive? NO\`)
- Real daemon boot on :18830 → \`[oep] http+ws listening\` → SIGTERM → \`[daemon] SIGTERM — killed 0 child process(es)\` → exit 0

## Risk

- **Bug 1 watchdog:** if a legitimate long-running task exceeds 30 min total or 5 min idle, it gets killed. Defaults are tunable via \`OFFICE_RUN_TOTAL_MS\` / \`OFFICE_RUN_IDLE_MS\`. The 5-min idle is generous for any tool-using run; pure-thinking turns (no tool calls) are rare for office agents.
- **Bug 4 settings:** the path is absolute (\`/Users/ar677005/...\`) — fine for this install; a portable rewrite would compute the path at install time, but that's a separate change.