### PR TITLE
hub: add waxwing — self-custody Antelope wallet (WAX · EOS · Telos · XPR)

### DIFF
--- a/web/plugins.json
+++ b/web/plugins.json
@@ -57,6 +57,7 @@
       "author": "bagidea",
       "repo": "https://github.com/bagidea/waxwing",
       "tags": ["tools", "wallet", "crypto"],
+      "official": true,
       "preview": "https://raw.githubusercontent.com/bagidea/waxwing/main/brand/preview-hero.png",
       "th": { "desc": "กระเป๋า self-custody สำหรับเชน Antelope (WAX · EOS · Telos · XPR, testnet & mainnet, ดีฟอลต์ WAX testnet) — สร้าง/นำเข้าคีย์เข้ารหัส AES-256-GCM + scrypt, รหัสผ่านเดียวปลดล็อกทุกเน็ตเวิร์ก, auto-lock, ส่ง/ stake/ unstake/ ซื้อ-ขาย RAM ผ่าน WharfKit, ส่งออก/นำเข้า wallet แบบเข้ารหัส · คีย์ไม่เคยออกจากเครื่อง" },
       "en": { "desc": "A self-custody wallet for Antelope chains (WAX · EOS · Telos · XPR, testnet & mainnet, default WAX testnet) — generate/import keys encrypted at rest (AES-256-GCM + scrypt), one wallet-level password unlocks all networks, auto-lock, send / stake / unstake / buy-sell RAM via WharfKit, encrypted export/import. Your keys never leave the machine." }

--- a/web/plugins.json
+++ b/web/plugins.json
@@ -1,6 +1,6 @@
 {
   "_comment": "BagIdea Office — community plugin catalog (source of truth for the Plugins Hub). To add a plugin: publish it as a public GitHub repo with a plugin.json, then open a PR adding an entry below. The owner reviews every PR (plugins run real code on a user's machine). 'id' MUST match the plugin's manifest id so the office can tell what's installed. See docs/guide/plugin-hub.md.",
-  "updated": "2026-06-24",
+  "updated": "2026-06-25",
   "plugins": [
     {
       "id": "agent-workbench",
@@ -50,6 +50,15 @@
       "official": true,
       "th": { "desc": "ดู agent เปิดเว็บสดในออฟฟิศ — สตรีม viewport ของ agent-browser (tool web-fast) เข้ามาในแผงแบบ pair-browsing เห็นน้องคลิก/พิมพ์เรียลไทม์ (ต้องลง agent-browser)" },
       "en": { "desc": "Watch an agent browse the web live inside the office — streams agent-browser's viewport into a panel (pair-browsing), so you see it click and type in real time. Requires agent-browser (the web-fast tool)." }
+    },
+    {
+      "id": "wax-wallet",
+      "name": "🪙 waxwing",
+      "author": "bagidea",
+      "repo": "https://github.com/bagidea/waxwing",
+      "tags": ["tools", "wallet", "crypto"],
+      "th": { "desc": "กระเป๋า self-custody สำหรับเชน Antelope (WAX · EOS · Telos · XPR, testnet & mainnet, ดีฟอลต์ WAX testnet) — สร้าง/นำเข้าคีย์เข้ารหัส AES-256-GCM + scrypt, รหัสผ่านเดียวปลดล็อกทุกเน็ตเวิร์ก, auto-lock, ส่ง/ stake/ unstake/ ซื้อ-ขาย RAM ผ่าน WharfKit, ส่งออก/นำเข้า wallet แบบเข้ารหัส · คีย์ไม่เคยออกจากเครื่อง" },
+      "en": { "desc": "A self-custody wallet for Antelope chains (WAX · EOS · Telos · XPR, testnet & mainnet, default WAX testnet) — generate/import keys encrypted at rest (AES-256-GCM + scrypt), one wallet-level password unlocks all networks, auto-lock, send / stake / unstake / buy-sell RAM via WharfKit, encrypted export/import. Your keys never leave the machine." }
     }
   ]
 }

--- a/web/plugins.json
+++ b/web/plugins.json
@@ -57,6 +57,7 @@
       "author": "bagidea",
       "repo": "https://github.com/bagidea/waxwing",
       "tags": ["tools", "wallet", "crypto"],
+      "preview": "https://raw.githubusercontent.com/bagidea/waxwing/main/brand/preview-hero.png",
       "th": { "desc": "กระเป๋า self-custody สำหรับเชน Antelope (WAX · EOS · Telos · XPR, testnet & mainnet, ดีฟอลต์ WAX testnet) — สร้าง/นำเข้าคีย์เข้ารหัส AES-256-GCM + scrypt, รหัสผ่านเดียวปลดล็อกทุกเน็ตเวิร์ก, auto-lock, ส่ง/ stake/ unstake/ ซื้อ-ขาย RAM ผ่าน WharfKit, ส่งออก/นำเข้า wallet แบบเข้ารหัส · คีย์ไม่เคยออกจากเครื่อง" },
       "en": { "desc": "A self-custody wallet for Antelope chains (WAX · EOS · Telos · XPR, testnet & mainnet, default WAX testnet) — generate/import keys encrypted at rest (AES-256-GCM + scrypt), one wallet-level password unlocks all networks, auto-lock, send / stake / unstake / buy-sell RAM via WharfKit, encrypted export/import. Your keys never leave the machine." }
     }


### PR DESCRIPTION
Add `waxwing` (wax-wallet) entry to the Plugins Hub catalog.

- **id**: `wax-wallet` (matches `plugin.json`)
- **repo**: https://github.com/bagidea/waxwing
- **4 Antelope chains**: WAX · EOS · Telos · XPR (testnet + mainnet)
- **Features**: wallet-level password, auto-lock, send/stake/unstake/RAM, encrypted export/import
- **Banner**: `brand/preview-hero.png` (3200×1600 @2x) — updated hero preview for Hub display

🤖 Generated with [Claude Code](https://claude.com/claude-code)