### PR TITLE
fix: kill child processes on shell exit (SIGTERM/SIGINT + parent-death watchdog)

### DIFF
--- a/daemon/server.js
+++ b/daemon/server.js
@@ -5992,3 +5992,25 @@ server.listen(OEP_PORT, "127.0.0.1", () => {
   // replays last and clears any stale working state on the wallpaper + overlay.
   broadcast({ type: "task.reset" });
 });
+
+// Parent-death watchdog: if the shell that spawned us (via OEP_SPAWNED=1) exits
+// or crashes, we self-shutdown instead of going orphan on PID 1 and holding port
+// 8787 forever. Polls every 3s — cheap, and 3s is fast enough to avoid port
+// collisions on a quick restart. Only active when OEP_SPAWNED is set, so a
+// manual `node server.js` from a terminal won't false-positive.
+if (process.env.OEP_SPAWNED === "1") {
+  const parentPid = process.ppid;
+  setInterval(() => {
+    try {
+      // process.kill(pid, 0) throws if the process no longer exists.
+      process.kill(parentPid, 0);
+    } catch {
+      console.log("[oep] parent shell exited — shutting down daemon.");
+      for (const child of runChildren.values()) {
+        try { child.kill("SIGTERM"); } catch {}
+      }
+      server.close();
+      process.exit(0);
+    }
+  }, 3000);
+}

--- a/shell/Cargo.toml
+++ b/shell/Cargo.toml
@@ -23,5 +23,8 @@ objc2 = "0.6"
 objc2-app-kit = { version = "0.3", features = ["NSWindow", "NSResponder", "NSView", "NSApplication", "NSRunningApplication", "NSScreen"] }
 objc2-foundation = { version = "0.3", features = ["NSGeometry", "NSArray", "NSString"] }
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [target.'cfg(windows)'.build-dependencies]
 winres = "0.1"

--- a/shell/src/main.rs
+++ b/shell/src/main.rs
@@ -1997,6 +1997,7 @@ fn main() {
                 let _ = godot.kill();
             }
             *control_flow = ControlFlow::Exit;
+            return;
         }
 
         // A slow poll tick keeps the tray channels live without pinning a core.

--- a/shell/src/main.rs
+++ b/shell/src/main.rs
@@ -18,6 +18,9 @@ use std::sync::atomic::{AtomicBool, Ordering};
 // Flipped true the moment the user quits from the tray, so the daemon watchdog
 // stops resurrecting the daemon we're deliberately tearing down.
 static SHUTTING_DOWN: AtomicBool = AtomicBool::new(false);
+// Flipped true by a Unix signal handler (SIGTERM/SIGINT) so the event loop
+// picks up the shutdown on its next tick — same cleanup path as tray Exit.
+static SIGNAL_SHUTDOWN: AtomicBool = AtomicBool::new(false);
 
 use tao::{
     dpi::{LogicalPosition, LogicalSize},
@@ -210,6 +213,11 @@ fn spawn_daemon(root: &PathBuf) -> Option<Child> {
     }
     let mut c = Command::new("node");
     c.arg(root.join("daemon").join("server.js"));
+    // Mark the daemon as shell-spawned so it enables parent-death detection
+    // (polls our PID and self-shuts-down if we crash/exit, instead of going
+    // orphan on PID 1 and holding port 8787 forever). A manual `node server.js`
+    // from a terminal won't have this env var, so it won't false-positive.
+    c.env("OEP_SPAWNED", "1");
     // A release GUI shell has NO console (windows_subsystem="windows"), so an
     // INHERITED stdout/stderr is an invalid handle and node can crash on its
     // first write — taking the daemon down seconds after launch. Send the
@@ -1780,6 +1788,21 @@ fn main() {
     // Make the website's one-click install reach us (idempotent; self-heals).
     platform::register_uri_scheme();
 
+    // ---- Unix signal handlers: SIGTERM/SIGINT → clean shutdown
+    // Without this, `kill <shell-pid>` or `launchctl unload` kills the shell
+    // but leaves the node daemon and Godot as orphans on PID 1.
+    #[cfg(unix)]
+    {
+        use std::os::raw::c_int;
+        extern "C" fn handle_signal(_sig: c_int) {
+            SIGNAL_SHUTDOWN.store(true, Ordering::Relaxed);
+        }
+        unsafe {
+            libc::signal(libc::SIGTERM, handle_signal as usize);
+            libc::signal(libc::SIGINT, handle_signal as usize);
+        }
+    }
+
     use wry::WebViewBuilder;
 
     // ---- boot the whole stack
@@ -1964,10 +1987,22 @@ fn main() {
     let mut vis_on = true;
     let mut last_watch = std::time::Instant::now();
     event_loop.run(move |event, target, control_flow| {
+        // Unix signal (SIGTERM/SIGINT) → same cleanup as tray Exit.
+        if SIGNAL_SHUTDOWN.load(Ordering::Relaxed) {
+            SHUTTING_DOWN.store(true, Ordering::Relaxed);
+            if let Some(ref mut daemon) = daemon {
+                let _ = daemon.kill();
+            }
+            if let Some(ref mut godot) = godot {
+                let _ = godot.kill();
+            }
+            *control_flow = ControlFlow::Exit;
+        }
+
         // A slow poll tick keeps the tray channels live without pinning a core.
         *control_flow = ControlFlow::WaitUntil(
-            std::time::Instant::now() + std::time::Duration::from_millis(250));
-
+            std::time::Instant::now() + std::time::Duration::from_millis(250),
+        );
         // Chat-head watchdog — THROTTLED. Re-asserting window state every tick
         // pins a CPU core on macOS (each level/visibility poke wakes the loop),
         // so we only check every ~2s and only touch the window when the orb has


### PR DESCRIPTION
Fixes #33

## Summary

When the Rust shell exits (crash/kill/launchctl unload), child processes (node daemon + Godot) survive as orphans on PID 1. The daemon holds port 8787 forever, blocking restarts.

## Changes

### `shell/src/main.rs`
- Added `SIGNAL_SHUTDOWN: AtomicBool` static
- Registered `SIGTERM`/`SIGINT` handlers via `libc::signal` that flip the atomic
- Event loop checks `SIGNAL_SHUTDOWN` each tick → kills daemon + Godot children → `ControlFlow::Exit`
- Set `OEP_SPAWNED=1` env var when spawning the daemon so it enables parent-death detection

### `shell/Cargo.toml`
- Added `libc = "0.2"` as Unix-only dependency (`[target.'cfg(unix)'.dependencies]`)

### `daemon/server.js`
- Added parent-death watchdog: when `OEP_SPAWNED=1`, poll `process.ppid` every 3s
- If parent shell is gone, kill all run children, close server, exit(0)
- Only active when shell-spawned — manual `node server.js` won't false-positive

## Verification

- `node --check daemon/server.js` ✅
- `grep SIGNAL_SHUTDOWN shell/src/main.rs` → 3 matches ✅
- `grep OEP_SPAWNED daemon/server.js` → 3 matches ✅
- `grep libc shell/Cargo.toml` → 1 match ✅